### PR TITLE
test(folder): Add folder service layer integration test #50

### DIFF
--- a/src/main/java/com/hyun/bookmarkshare/manage/folder/controller/FolderRestController.java
+++ b/src/main/java/com/hyun/bookmarkshare/manage/folder/controller/FolderRestController.java
@@ -1,15 +1,19 @@
 package com.hyun.bookmarkshare.manage.folder.controller;
 
 import com.hyun.bookmarkshare.manage.folder.controller.dto.*;
-import com.hyun.bookmarkshare.manage.folder.entity.Folder;
 import com.hyun.bookmarkshare.manage.folder.service.FolderService;
+import com.hyun.bookmarkshare.manage.folder.service.request.FolderReorderServiceRequestDto;
+import com.hyun.bookmarkshare.manage.folder.service.response.FolderReorderResponse;
+import com.hyun.bookmarkshare.manage.folder.service.response.FolderResponse;
+import com.hyun.bookmarkshare.manage.folder.service.response.FolderSeqResponse;
+import com.hyun.bookmarkshare.utils.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @RestController
@@ -20,32 +24,36 @@ public class FolderRestController {
 
     // 특정 부모폴더 내부에 속한 폴더 List 조회
     @GetMapping("/manage/folder/list")
-    public ResponseEntity<FolderListResponseEntity> getFolderListRequest(@Valid @RequestBody FolderListRequestDto requestDto){
-        return FolderListResponseEntity.toResponseEntity(folderService.findFolderList(requestDto));
+    public ApiResponse<List<FolderResponse>> getFolderListRequest(@Valid @RequestBody FolderListRequestDto requestDto){
+        return ApiResponse.of(HttpStatus.OK,
+                "폴더 리스트 조회 완료",
+                folderService.findFolderList(requestDto.toServiceDto())
+        );
     }
 
     // 특정 부모폴더 내부에 신규 폴더 생성
-    @PostMapping("/manage/folder/addFolder")
-    public ResponseEntity<FolderResponseEntity> addFolderRequest(@Valid @RequestBody FolderCreateRequestDto requestDto){
-        Folder resultFolder = folderService.createFolder(requestDto.toServiceRequestDto());
-        return FolderResponseEntity.toResponseEntity(resultFolder);
+    @PostMapping("/api/v1/manage/folder/new")
+    public ApiResponse<FolderResponse> addFolderRequest(@Valid @RequestBody FolderCreateRequestDto requestDto){
+        FolderResponse resultFolderResponse = folderService.createFolder(requestDto.toServiceRequestDto());
+        return ApiResponse.of(HttpStatus.OK, "신규 폴더 생성 완료", resultFolderResponse);
     }
+
 
     // 특정 폴더 삭제
     @DeleteMapping("/manage/folder/delete")
-    public ResponseEntity<FolderSeqResponseEntity> deleteFolderRequest(@Valid @RequestBody FolderRequestDto requestDto){
-        return FolderSeqResponseEntity.toResponseEntity(folderService.deleteFolder(requestDto));
+    public ApiResponse<FolderSeqResponse> deleteFolderRequest(@Valid @RequestBody FolderRequestDto requestDto){
+        return ApiResponse.of(HttpStatus.OK, "폴더 삭제 완료", folderService.deleteFolder(requestDto.toServiceDto()));
     }
 
     // 특정 폴더 정보 수정
     @PatchMapping("/manage/folder/update")
-    public ResponseEntity<FolderResponseEntity> updateFolderRequest(@Valid @RequestBody FolderRequestDto requestDto){
-        return FolderResponseEntity.toResponseEntity(folderService.updateFolder(requestDto));
+    public ApiResponse<FolderResponse> updateFolderRequest(@Valid @RequestBody FolderRequestDto requestDto){
+        return ApiResponse.of(HttpStatus.OK, "폴더 수정 완료", folderService.updateFolder(requestDto.toServiceDto()));
     }
 
     // 특정 부모폴더들 내부의 순서 수정
     @PostMapping("/manage/folder/reorder")
-    public ResponseEntity<FolderReorderResponseEntity> reorderFolderRequest(@Valid @RequestBody List<FolderReorderRequestDto> requestDtoList){
+    public ApiResponse<List<FolderReorderResponse>> reorderFolderRequest(@Valid @RequestBody List<FolderReorderRequestDto> requestDtoList){
         /*
         * JSON DATA REQUEST FORMAT EXAMPLE
         *
@@ -55,13 +63,18 @@ public class FolderRestController {
             ]
         *
         * */
-        return FolderReorderResponseEntity.toResponseEntity(
-                folderService.updateFolderOrder(
-                        requestDtoList.stream()
-                                .map(dto -> dto.toServiceRequestDto())
-                                .collect(Collectors.toList())
-                )
-        );
+//        return FolderReorderResponseEntity.toResponseEntity(
+//                folderService.updateFolderOrder(
+//                        requestDtoList.stream()
+//                                .map(dto -> dto.toServiceRequestDto())
+//                                .collect(Collectors.toList())
+//                )
+//        );
+        List<FolderReorderServiceRequestDto> serviceRequestDtoList = requestDtoList.stream()
+                .map(dto -> dto.toServiceRequestDto())
+                .collect(Collectors.toList());
+        List<FolderReorderResponse> reorderResponseList = folderService.updateFolderOrder(serviceRequestDtoList);
+        return ApiResponse.of(HttpStatus.OK, "폴더 순서 수정 완료", reorderResponseList);
     }
 
 }

--- a/src/main/java/com/hyun/bookmarkshare/manage/folder/controller/dto/FolderListRequestDto.java
+++ b/src/main/java/com/hyun/bookmarkshare/manage/folder/controller/dto/FolderListRequestDto.java
@@ -1,9 +1,7 @@
 package com.hyun.bookmarkshare.manage.folder.controller.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import com.hyun.bookmarkshare.manage.folder.service.request.FolderListServiceRequestDto;
+import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -11,9 +9,7 @@ import javax.validation.constraints.Positive;
 import javax.validation.constraints.PositiveOrZero;
 
 @Getter
-@Setter
-@AllArgsConstructor
-@ToString
+@NoArgsConstructor
 public class FolderListRequestDto {
 
     @NotNull
@@ -23,4 +19,18 @@ public class FolderListRequestDto {
     @NotNull
     @PositiveOrZero
     private Long folderParentSeq;
+
+    @Builder
+    public FolderListRequestDto(Long userId, Long folderParentSeq) {
+        this.userId = userId;
+        this.folderParentSeq = folderParentSeq;
+    }
+
+    public FolderListServiceRequestDto toServiceDto(){
+        return FolderListServiceRequestDto.builder()
+                .userId(userId)
+                .folderParentSeq(folderParentSeq)
+                .build();
+    }
+
 }

--- a/src/main/java/com/hyun/bookmarkshare/manage/folder/controller/dto/FolderRequestDto.java
+++ b/src/main/java/com/hyun/bookmarkshare/manage/folder/controller/dto/FolderRequestDto.java
@@ -1,14 +1,13 @@
 package com.hyun.bookmarkshare.manage.folder.controller.dto;
 
+import com.hyun.bookmarkshare.manage.folder.service.request.FolderServiceRequestDto;
 import lombok.*;
 
 import javax.validation.constraints.*;
 
-@Builder
 @ToString
 @Getter
-@Setter
-@AllArgsConstructor
+@NoArgsConstructor
 public class FolderRequestDto {
 
     @NotNull
@@ -35,5 +34,24 @@ public class FolderRequestDto {
     @PositiveOrZero
     private Long folderParentSeq;
 
+    @Builder
+    public FolderRequestDto(Long folderSeq, Long userId, String folderName, String folderCaption, String folderScope, Long folderParentSeq) {
+        this.folderSeq = folderSeq;
+        this.userId = userId;
+        this.folderName = folderName;
+        this.folderCaption = folderCaption;
+        this.folderScope = folderScope;
+        this.folderParentSeq = folderParentSeq;
+    }
 
+    public FolderServiceRequestDto toServiceDto(){
+        return FolderServiceRequestDto.builder()
+                .folderSeq(folderSeq)
+                .userId(userId)
+                .folderName(folderName)
+                .folderCaption(folderCaption)
+                .folderScope(folderScope)
+                .folderParentSeq(folderParentSeq)
+                .build();
+    }
 }

--- a/src/main/java/com/hyun/bookmarkshare/manage/folder/dao/FolderRepository.java
+++ b/src/main/java/com/hyun/bookmarkshare/manage/folder/dao/FolderRepository.java
@@ -23,15 +23,16 @@ public interface FolderRepository {
     List<Folder> findAllByUserIdAndParentSeq(Long userId, Long folderParentSeq);
     List<Folder> findAllByUserId(Long userId);
     Optional<Folder> findByFolderSeq(Long folderSeq);
-
+    Optional<Folder> findByFolderSeqExcludeDeleted(Long folderSeq);
+    List<Long> findAllFolderSeqWithSameAncestor(long ancestor, long userId);
 
     // INSERT
     int save(Folder folder);
-    // Long saveNewFolder(Folder folder);
+    int saveFolderAsCustom(Folder folder);
 
     // UPDATE
-
     int updateByFolderRequestDto(FolderRequestDto requestDto);
+
     int updateOrderByFolderServiceRequestDto(FolderReorderServiceRequestDto folderReorderServiceRequestDto);
 
     // DELETE
@@ -40,7 +41,6 @@ public interface FolderRepository {
 
     // ONLY FOR TEST
 
-    Optional<Folder> findByFolderSeqEvenIfDeleted(Long folderSeq);
 
     int update(Folder folder);
 }

--- a/src/main/java/com/hyun/bookmarkshare/manage/folder/entity/Folder.java
+++ b/src/main/java/com/hyun/bookmarkshare/manage/folder/entity/Folder.java
@@ -52,4 +52,12 @@ public class Folder {
                 ", folderDelFlag='" + folderDelFlag + '\'' +
                 '}';
     }
+
+    public Folder updateEntityBy(Folder requestFolder) {
+        this.folderName = requestFolder.getFolderName();
+        this.folderCaption = requestFolder.getFolderCaption();
+        this.folderScope = requestFolder.getFolderScope();
+        return this;
+    }
+
 }

--- a/src/main/java/com/hyun/bookmarkshare/manage/folder/service/FolderRequestValidator.java
+++ b/src/main/java/com/hyun/bookmarkshare/manage/folder/service/FolderRequestValidator.java
@@ -51,7 +51,7 @@ public class FolderRequestValidator {
 
     // 제어 가능한 폴더인지 (제어하려는 폴더식별번호가 루트(0)폴더가 아니며 & 존재하는/접근가능한 폴더여야 한다)
     private void availableUpdateFolderSeq(Long folderSeq){
-        folderRepository.findByFolderSeq(folderSeq)
+        folderRepository.findByFolderSeqExcludeDeleted(folderSeq)
                 .filter(folder -> !folder.getFolderSeq().equals(0))
                 .orElseThrow(() -> {
                     throw new FolderRequestException(FolderExceptionErrorCode.NOT_FOUND_FOLDER, "존재 하지 않거나 제어 불가한 폴더 입니다");
@@ -60,7 +60,7 @@ public class FolderRequestValidator {
 
     // 조회 가능한 폴더인지 (조회하려는 폴더식별번호가 존재하는/접근가능한 폴더여야 한다)
     private void availableSelectFolderSeq(Long folderParentSeq){
-        folderRepository.findByFolderSeq(folderParentSeq)
+        folderRepository.findByFolderSeqExcludeDeleted(folderParentSeq)
                 .orElseThrow(()->{
                     throw new NoSuchElementException("");
                 });

--- a/src/main/java/com/hyun/bookmarkshare/manage/folder/service/FolderService.java
+++ b/src/main/java/com/hyun/bookmarkshare/manage/folder/service/FolderService.java
@@ -1,15 +1,14 @@
 package com.hyun.bookmarkshare.manage.folder.service;
 
-import com.hyun.bookmarkshare.manage.folder.controller.dto.FolderCreateRequestDto;
-import com.hyun.bookmarkshare.manage.folder.controller.dto.FolderListRequestDto;
-import com.hyun.bookmarkshare.manage.folder.controller.dto.FolderReorderRequestDto;
-import com.hyun.bookmarkshare.manage.folder.controller.dto.FolderRequestDto;
-import com.hyun.bookmarkshare.manage.folder.entity.Folder;
 import com.hyun.bookmarkshare.manage.folder.service.request.FolderCreateServiceRequestDto;
+import com.hyun.bookmarkshare.manage.folder.service.request.FolderListServiceRequestDto;
 import com.hyun.bookmarkshare.manage.folder.service.request.FolderReorderServiceRequestDto;
+import com.hyun.bookmarkshare.manage.folder.service.request.FolderServiceRequestDto;
+import com.hyun.bookmarkshare.manage.folder.service.response.FolderReorderResponse;
+import com.hyun.bookmarkshare.manage.folder.service.response.FolderResponse;
+import com.hyun.bookmarkshare.manage.folder.service.response.FolderSeqResponse;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -19,17 +18,17 @@ public interface FolderService {
      * @param requestDto FolderListRequestDto
      * @return list of folder
      * */
-    List<Folder> findFolderList(FolderListRequestDto requestDto);
+    List<FolderResponse> findFolderList(FolderListServiceRequestDto requestDto);
 
     /**@param requestDto
      * @return repository sql result - success : 1
      * @implNote explain
      * */
-    Folder createFolder(FolderCreateServiceRequestDto requestDto);
+    FolderResponse createFolder(FolderCreateServiceRequestDto requestDto);
 
-    Long deleteFolder(FolderRequestDto requestDto);
+    FolderSeqResponse deleteFolder(FolderServiceRequestDto requestDto);
 
-    Folder updateFolder(FolderRequestDto requestDto);
+    FolderResponse updateFolder(FolderServiceRequestDto requestDto);
 
-    List<Long> updateFolderOrder(List<FolderReorderServiceRequestDto> requestDtoList);
+    List<FolderReorderResponse> updateFolderOrder(List<FolderReorderServiceRequestDto> requestDtoList);
 }

--- a/src/main/java/com/hyun/bookmarkshare/manage/folder/service/FolderServiceImpl.java
+++ b/src/main/java/com/hyun/bookmarkshare/manage/folder/service/FolderServiceImpl.java
@@ -1,81 +1,102 @@
 package com.hyun.bookmarkshare.manage.folder.service;
 
-import com.hyun.bookmarkshare.manage.bookmark.dao.BookmarkRepository;
-import com.hyun.bookmarkshare.manage.folder.controller.dto.FolderCreateRequestDto;
-import com.hyun.bookmarkshare.manage.folder.controller.dto.FolderListRequestDto;
-import com.hyun.bookmarkshare.manage.folder.controller.dto.FolderReorderRequestDto;
-import com.hyun.bookmarkshare.manage.folder.controller.dto.FolderRequestDto;
+import com.hyun.bookmarkshare.manage.bookmark.service.BookmarkService;
 import com.hyun.bookmarkshare.manage.folder.dao.FolderRepository;
 import com.hyun.bookmarkshare.manage.folder.entity.Folder;
 import com.hyun.bookmarkshare.manage.folder.exceptions.FolderExceptionErrorCode;
 import com.hyun.bookmarkshare.manage.folder.exceptions.FolderRequestException;
 import com.hyun.bookmarkshare.manage.folder.service.request.FolderCreateServiceRequestDto;
+import com.hyun.bookmarkshare.manage.folder.service.request.FolderListServiceRequestDto;
 import com.hyun.bookmarkshare.manage.folder.service.request.FolderReorderServiceRequestDto;
+import com.hyun.bookmarkshare.manage.folder.service.request.FolderServiceRequestDto;
+import com.hyun.bookmarkshare.manage.folder.service.response.FolderReorderResponse;
+import com.hyun.bookmarkshare.manage.folder.service.response.FolderResponse;
+import com.hyun.bookmarkshare.manage.folder.service.response.FolderSeqResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class FolderServiceImpl implements FolderService{
 
     private final FolderRepository folderRepository;
+    private final BookmarkService bookmarkService;
     private final FolderRequestValidator validator;
-    private final BookmarkRepository bookmarkRepository;
 
     @Override
-    public List<Folder> findFolderList(FolderListRequestDto requestDto) {
-//        validator.check(requestDto);
-        return folderRepository.findAllByUserIdAndParentSeq(requestDto.getUserId(), requestDto.getFolderParentSeq());
+    public List<FolderResponse> findFolderList(FolderListServiceRequestDto requestDto) {
+        List<Folder> resultFolders = folderRepository.findAllByUserIdAndParentSeq(
+                requestDto.getUserId(),
+                requestDto.getFolderParentSeq()
+        );
+        return resultFolders.stream()
+                .map(FolderResponse::of)
+                .collect(Collectors.toList());
     }
 
     @Override
-    public Folder createFolder(FolderCreateServiceRequestDto serviceRequestDto) {
-        // 검증 ( 폴더명, 폴더레벨, 공유범위) - 미 충족 시 예외
+    public FolderResponse createFolder(FolderCreateServiceRequestDto serviceRequestDto) {
         Folder targetFolder = serviceRequestDto.toFolder();
-        int resultRows = folderRepository.save(targetFolder);
-        return folderRepository.findByFolderSeq(targetFolder.getFolderSeq())
+        folderRepository.save(targetFolder);
+        return FolderResponse.of(folderRepository.findByFolderSeqExcludeDeleted(targetFolder.getFolderSeq())
+                .orElseThrow(() -> new NoSuchElementException("Not Found Folder")));
+    }
+
+    @Override
+    public FolderSeqResponse deleteFolder(FolderServiceRequestDto requestDto) {
+        // TODO : [검증] 1) requestDto 에 대한 도메인 정책 검증, 2) 각 쿼리 수행결과에 대한 검증
+
+        // 1. 삭제 요청 받은 폴더의 식별번호로 하위 폴더 식별번호 리스트를 조회.
+        List<Long> deleteTarget = folderRepository.findAllFolderSeqWithSameAncestor(requestDto.getFolderSeq(), requestDto.getUserId());
+        // 2. 리스트에 요청받은 폴더의 식별번호를 추가.
+        deleteTarget.add(requestDto.getFolderSeq());
+        // 3. 리스트에 담긴 폴더 식별번호로 폴더 삭제 처리
+        deleteTarget.stream().forEach(folderRepository::deleteByFolderSeq);
+        // 4. 각 폴더 내부의 북마크 삭제 처리
+//        bookmarkService.deleteAllBookmarkInFolderList(deleteTarget);
+        return FolderSeqResponse.builder()
+                .userId(requestDto.getUserId())
+                .folderSeqList(deleteTarget)
+                .build();
+    }
+
+    @Override
+    public FolderResponse updateFolder(FolderServiceRequestDto requestDto) {
+        // 1. 요청 받은 폴더 식별번호로 폴더 조회
+        Folder updateTarget = folderRepository.findByFolderSeqExcludeDeleted(requestDto.getFolderSeq())
                 .orElseThrow(() -> new NoSuchElementException("Not Found Folder"));
+        // 2. 조회된 폴더 엔티티를 요청받은 폴더 엔티티로 업데이트
+        Folder updatedTarget = updateTarget.updateEntityBy(requestDto.toEntity());
+        // 3. 업데이트된 폴더 엔티티를 저장
+        folderRepository.update(updatedTarget);
+//        validateSqlUpdatedRows(updatedRows);
+        return FolderResponse.of(folderRepository.findByFolderSeqExcludeDeleted(requestDto.getFolderSeq())
+                                    .orElseThrow(()->new NoSuchElementException("Not Found Folder"))
+        );
     }
 
     @Override
-    public Long deleteFolder(FolderRequestDto requestDto) {
-        // 검증 ( 폴더식별번호가 혹시 0은 아닌지, 삭제할 대상이 있는지)
-        validator.check(requestDto);
-        // 폴더 삭제 처리
-        int deletedRows = folderRepository.deleteByFolderSeq(requestDto.getFolderSeq());
-        validateSqlUpdatedRows(deletedRows);
-        // 폴더 내부의 북마크 삭제 처리
-//        int folderDeletedRows = bookmarkRepository.deleteByFolderSeq(requestDto.getFolderSeq());
-        return requestDto.getFolderSeq();
-    }
-
-    @Override
-    public Folder updateFolder(FolderRequestDto requestDto) {
-        validator.check(requestDto);
-
-        int updatedRows = folderRepository.updateByFolderRequestDto(requestDto);
-        validateSqlUpdatedRows(updatedRows);
-        return folderRepository.findByFolderSeq(requestDto.getFolderSeq())
-                .orElseThrow(()->new NoSuchElementException("Not Found Folder"));
-    }
-
-    @Override
-    public List<Long> updateFolderOrder(List<FolderReorderServiceRequestDto> serviceRequestDtoList) {
-        validator.check(serviceRequestDtoList);
-        for ( FolderReorderServiceRequestDto folderReorderServiceRequestDto : serviceRequestDtoList) {
-            int updatedRows = folderRepository.updateOrderByFolderServiceRequestDto(folderReorderServiceRequestDto);
-            validateSqlUpdatedRows(updatedRows);
+    public List<FolderReorderResponse> updateFolderOrder(List<FolderReorderServiceRequestDto> serviceRequestDtoList) {
+        for (FolderReorderServiceRequestDto folderReorderServiceRequestDto : serviceRequestDtoList) {
+            folderRepository.updateOrderByFolderServiceRequestDto(folderReorderServiceRequestDto);
         }
-        List<Long> result = new ArrayList<>();
-
-        serviceRequestDtoList.forEach(folderReorderRequestDto -> {
-            result.add(folderReorderRequestDto.getFolderParentSeq());
-        });
-        return result;
+        // TODO : data 를 포함하지 않고 성공 여부만 응답하는 것이 좋을지 고민해보자.
+        return serviceRequestDtoList.stream()
+                .map(dto -> FolderReorderResponse.builder()
+                            .userId(dto.getUserId())
+                            .folderParentSeq(dto.getFolderParentSeq())
+                            .folderSeqOrder(
+                                folderRepository.findAllByUserIdAndParentSeq(dto.getUserId(), dto.getFolderParentSeq())
+                                    .stream()
+                                    .map(Folder::getFolderSeq)
+                                    .collect(Collectors.toList())
+                            )
+                            .build())
+                .collect(Collectors.toList());
     }
 
     /** Validate (INSERT, UPDATE, DELETE) Result Rows */

--- a/src/main/java/com/hyun/bookmarkshare/manage/folder/service/request/FolderListServiceRequestDto.java
+++ b/src/main/java/com/hyun/bookmarkshare/manage/folder/service/request/FolderListServiceRequestDto.java
@@ -1,0 +1,20 @@
+package com.hyun.bookmarkshare.manage.folder.service.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+
+@Getter
+public class FolderListServiceRequestDto {
+
+    private Long userId;
+    private Long folderParentSeq;
+
+    @Builder
+    public FolderListServiceRequestDto(Long userId, Long folderParentSeq) {
+        this.userId = userId;
+        this.folderParentSeq = folderParentSeq;
+    }
+}

--- a/src/main/java/com/hyun/bookmarkshare/manage/folder/service/request/FolderServiceRequestDto.java
+++ b/src/main/java/com/hyun/bookmarkshare/manage/folder/service/request/FolderServiceRequestDto.java
@@ -5,34 +5,33 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class FolderCreateServiceRequestDto {
+public class FolderServiceRequestDto {
 
     private Long folderSeq;
     private Long userId;
-    private Long folderParentSeq;
     private String folderName;
     private String folderCaption;
     private String folderScope;
+    private Long folderParentSeq;
 
     @Builder
-    public FolderCreateServiceRequestDto(Long folderSeq, Long userId, Long folderParentSeq, String folderName, String folderCaption, String folderScope) {
+    public FolderServiceRequestDto(Long folderSeq, Long userId, String folderName, String folderCaption, String folderScope, Long folderParentSeq) {
         this.folderSeq = folderSeq;
         this.userId = userId;
-        this.folderParentSeq = folderParentSeq;
         this.folderName = folderName;
         this.folderCaption = folderCaption;
         this.folderScope = folderScope;
+        this.folderParentSeq = folderParentSeq;
     }
 
-    public Folder toFolder() {
+    public Folder toEntity(){
         return Folder.builder()
                 .folderSeq(this.folderSeq)
                 .userId(this.userId)
-                .folderParentSeq(this.folderParentSeq)
-                .folderRootFlag("n")
                 .folderName(this.folderName)
                 .folderCaption(this.folderCaption)
                 .folderScope(this.folderScope)
+                .folderParentSeq(this.folderParentSeq)
                 .build();
     }
 }

--- a/src/main/java/com/hyun/bookmarkshare/manage/folder/service/response/FolderReorderResponse.java
+++ b/src/main/java/com/hyun/bookmarkshare/manage/folder/service/response/FolderReorderResponse.java
@@ -1,0 +1,21 @@
+package com.hyun.bookmarkshare.manage.folder.service.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class FolderReorderResponse {
+
+    private Long userId;
+    private Long folderParentSeq;
+    private List<Long> folderSeqOrder;
+
+    @Builder
+    public FolderReorderResponse(Long userId, Long folderParentSeq, List<Long> folderSeqOrder) {
+        this.userId = userId;
+        this.folderParentSeq = folderParentSeq;
+        this.folderSeqOrder = folderSeqOrder;
+    }
+}

--- a/src/main/java/com/hyun/bookmarkshare/manage/folder/service/response/FolderResponse.java
+++ b/src/main/java/com/hyun/bookmarkshare/manage/folder/service/response/FolderResponse.java
@@ -1,0 +1,51 @@
+package com.hyun.bookmarkshare.manage.folder.service.response;
+
+import com.hyun.bookmarkshare.manage.folder.entity.Folder;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class FolderResponse {
+
+    private Long folderSeq;
+    private Long userId;
+    private Long folderParentSeq;
+    private String folderRootFlag;
+    private String folderName;
+    private String folderCaption;
+    private Long folderOrder;
+    private String folderScope;
+    private LocalDateTime folderRegDate;
+    private LocalDateTime folderModDate;
+
+    @Builder
+    public FolderResponse(Long folderSeq, Long userId, Long folderParentSeq, String folderRootFlag, String folderName, String folderCaption, Long folderOrder, String folderScope, LocalDateTime folderRegDate, LocalDateTime folderModDate) {
+        this.folderSeq = folderSeq;
+        this.userId = userId;
+        this.folderParentSeq = folderParentSeq;
+        this.folderRootFlag = folderRootFlag;
+        this.folderName = folderName;
+        this.folderCaption = folderCaption;
+        this.folderOrder = folderOrder;
+        this.folderScope = folderScope;
+        this.folderRegDate = folderRegDate;
+        this.folderModDate = folderModDate;
+    }
+
+    public static FolderResponse of(Folder folder){
+        return FolderResponse.builder()
+                .folderSeq(folder.getFolderSeq())
+                .userId(folder.getUserId())
+                .folderParentSeq(folder.getFolderParentSeq())
+                .folderRootFlag(folder.getFolderRootFlag())
+                .folderName(folder.getFolderName())
+                .folderCaption(folder.getFolderCaption())
+                .folderOrder(folder.getFolderOrder())
+                .folderScope(folder.getFolderScope())
+                .folderRegDate(folder.getFolderRegDate())
+                .folderModDate(folder.getFolderModDate())
+                .build();
+    }
+}

--- a/src/main/java/com/hyun/bookmarkshare/manage/folder/service/response/FolderSeqResponse.java
+++ b/src/main/java/com/hyun/bookmarkshare/manage/folder/service/response/FolderSeqResponse.java
@@ -1,0 +1,19 @@
+package com.hyun.bookmarkshare.manage.folder.service.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class FolderSeqResponse {
+
+    private Long userId;
+    private List<Long> folderSeqList;
+
+    @Builder
+    public FolderSeqResponse(Long userId, List<Long> folderSeqList) {
+        this.userId = userId;
+        this.folderSeqList = folderSeqList;
+    }
+}

--- a/src/main/java/com/hyun/bookmarkshare/smtp/service/EmailService.java
+++ b/src/main/java/com/hyun/bookmarkshare/smtp/service/EmailService.java
@@ -5,6 +5,7 @@ import com.hyun.bookmarkshare.smtp.dao.EmailRepository;
 import com.hyun.bookmarkshare.smtp.exception.EmailExceptionErrorCode;
 import com.hyun.bookmarkshare.smtp.exception.EmailProcessException;
 import com.hyun.bookmarkshare.user.dao.UserRepository;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,7 +27,9 @@ public class EmailService {
     private final JavaMailSender javaMailSender;
     private final EmailRepository emailRepository;
     private final UserRepository userRepository;
-    private final @Value("${email.value.property}") String fromEmail;
+    // TODO : 왜 final 로 선언했을 때 에러가 나는지 확인 필요.
+    @Value("${email.value.property}")
+    private String fromEmail;
 
     /**
      * 이메일 인증 코드 발송 로직.

--- a/src/main/java/com/hyun/bookmarkshare/user/dao/UserRepository.java
+++ b/src/main/java/com/hyun/bookmarkshare/user/dao/UserRepository.java
@@ -23,7 +23,7 @@ public interface UserRepository {
 
     /* TUSERACCOUNT TABLE */
     Optional<User> findByUserId(Long userId);
-    Optional<User> findByUserIdAndState(@Param("userId") Long userId, @Param("userState") String userState);
+    Optional<User> findByUserIdAndUserState(@Param("userId") Long userId, @Param("userState") String userState);
 
     /* TUSERACCOUNT TABLE */
     Integer countByUserEmail(String userEmail);

--- a/src/main/java/com/hyun/bookmarkshare/utils/ApiResponse.java
+++ b/src/main/java/com/hyun/bookmarkshare/utils/ApiResponse.java
@@ -1,0 +1,37 @@
+package com.hyun.bookmarkshare.utils;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ApiResponse<T> {
+
+    private final LocalDateTime timestamp = LocalDateTime.now();
+    private int code;
+    private HttpStatus status;
+    private String message;
+    private T data;
+
+    public ApiResponse(HttpStatus status, String message, T data) {
+        this.code = status.value();
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> of(HttpStatus status, String message, T data) {
+        return new ApiResponse<>(status, message, data);
+    }
+
+    public static <T> ApiResponse<T> of(HttpStatus status, T data) {
+        return of(status, status.name(), data);
+    }
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return of(HttpStatus.OK, data);
+    }
+
+
+}

--- a/src/main/resources/mapper/FolderMapper.xml
+++ b/src/main/resources/mapper/FolderMapper.xml
@@ -40,29 +40,51 @@
                                  resultMap="folderEntityResultMap">
         SELECT *
         FROM TFOLDER
+        WHERE FOLDER_SEQ = #{folderSeq}
+        LIMIT 1;
+    </select>
+
+    <select id="findByFolderSeqExcludeDeleted" resultType="com.hyun.bookmarkshare.manage.folder.entity.Folder"
+                                               resultMap="folderEntityResultMap">
+        SELECT *
+        FROM TFOLDER
         WHERE FOLDER_SEQ = #{folderSeq} AND FOLDER_DEL_FLAG = 'n'
         LIMIT 1;
     </select>
 
-    <select id="findByFolderSeqEvenIfDeleted" resultType="Long" resultMap="folderEntityResultMap">
-        SELECT *
-        FROM TFOLDER
-        WHERE FOLDER_SEQ = #{folderSeq};
+    <select id="findAllFolderSeqWithSameAncestor" resultType="Long">
+        WITH RECURSIVE CTE AS (
+            SELECT
+                FOLDER_SEQ,
+                FOLDER_PARENT_SEQ
+            FROM tfolder
+            WHERE FOLDER_PARENT_SEQ = #{ancestor} AND USER_SEQ = #{userId} AND FOLDER_DEL_FLAG = 'n'
+
+            UNION ALL
+
+            SELECT
+                a.FOLDER_SEQ,
+                a.FOLDER_PARENT_SEQ
+            FROM tfolder a
+
+            INNER JOIN CTE b ON a.FOLDER_PARENT_SEQ = b.FOLDER_SEQ
+        )
+        SELECT FOLDER_SEQ, FOLDER_PARENT_SEQ FROM CTE;
     </select>
 
     <!-- ================================================================================================ -->
     <!-- ============================================ INSERT ============================================ -->
 
     <!--    1) 정상 동작 확인 완료 -->
-    <insert id="saveNewFolder" parameterType="com.hyun.bookmarkshare.manage.folder.entity.Folder"
+    <insert id="saveFolderAsCustom" parameterType="com.hyun.bookmarkshare.manage.folder.entity.Folder"
                                 useGeneratedKeys="true" keyProperty="folderSeq">
         INSERT
         INTO TFOLDER(FOLDER_SEQ, USER_SEQ, FOLDER_PARENT_SEQ, FOLDER_ROOT_FLAG, FOLDER_NAME, FOLDER_CAPTION,
                      FOLDER_ORDER,
                      FOLDER_SCOPE, FOLDER_REG_DATE, FOLDER_MOD_DATE, FOLDER_DEL_FLAG)
         VALUES (#{folderSeq}, #{userId}, #{folderParentSeq}, #{folderRootFlag}, #{folderName}, #{folderCaption},
-                (SELECT MAX(FOLDER_ORDER)+1 FROM TFOLDER ALIAS_FOR_SUBQUERY WHERE USER_SEQ = #{userId} AND FOLDER_PARENT_SEQ = #{folderParentSeq}),
-                #{folderScope}, NOW(), NOW(), 'n'
+                (SELECT IFNULL(MAX(FOLDER_ORDER)+1, 1) FROM TFOLDER ALIAS_FOR_SUBQUERY WHERE USER_SEQ = #{userId} AND FOLDER_PARENT_SEQ = #{folderParentSeq}),
+                #{folderScope}, NOW(), NOW(), #{folderDelFlag}
                 );
     </insert>
 
@@ -72,10 +94,10 @@
         INTO TFOLDER(FOLDER_SEQ, USER_SEQ, FOLDER_PARENT_SEQ, FOLDER_ROOT_FLAG, FOLDER_NAME, FOLDER_CAPTION,
                      FOLDER_ORDER,
                      FOLDER_SCOPE, FOLDER_REG_DATE, FOLDER_MOD_DATE, FOLDER_DEL_FLAG)
-        VALUES (#{folderSeq}, #{userId}, #{folderParentSeq}, #{folderRootFlag}, #{folderName}, #{folderCaption},
+        VALUES (#{folderSeq}, #{userId}, #{folderParentSeq}, #{folderRootFlag}, #{folderName}, IFNULL(#{folderCaption}, ''),
                 <choose>
                     <when test='folderOrder == null'>
-                        (SELECT MAX(FOLDER_ORDER)+1 FROM TFOLDER ALIAS_FOR_SUBQUERY WHERE USER_SEQ = #{userId} AND FOLDER_PARENT_SEQ = #{folderParentSeq})
+                        (SELECT IFNULL(MAX(FOLDER_ORDER)+1, 1) FROM TFOLDER ALIAS_FOR_SUBQUERY WHERE USER_SEQ = #{userId} AND FOLDER_PARENT_SEQ = #{folderParentSeq})
                     </when>
                     <otherwise>
                         #{folderOrder}

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -27,12 +27,12 @@
         SELECT * FROM TUSERACCOUNT WHERE USER_EMAIL = #{email} AND USER_PWD = #{pwd} AND USER_STATE = 'n';
     </select>
 
-    <select id="findByUserIdAndState" resultMap="userEntityResultMap">
+    <select id="findByUserIdAndUserState" resultMap="userEntityResultMap">
         SELECT * FROM TUSERACCOUNT WHERE USER_SEQ = #{userId} AND USER_STATE = #{userState};
     </select>
 
     <select id="findByUserId" resultMap="userEntityResultMap">
-        SELECT * FROM TUSERACCOUNT WHERE USER_SEQ = #{userId} AND USER_STATE = 'n' ;
+        SELECT * FROM TUSERACCOUNT WHERE USER_SEQ = #{userId};
     </select>
 
     <select id="findByRefreshToken" parameterType="string" resultMap="userTokenResultMap">

--- a/src/test/java/com/hyun/bookmarkshare/manage/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/com/hyun/bookmarkshare/manage/bookmark/service/BookmarkServiceTest.java
@@ -1,0 +1,28 @@
+package com.hyun.bookmarkshare.manage.bookmark.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@SpringBootTest
+@Transactional
+public class BookmarkServiceTest {
+
+    @Autowired
+    private BookmarkService bookmarkService;
+
+    @DisplayName("폴더 삭제 시, 대상 폴더에 포함된 북마크들의 deleteFlag 는 'y'로 변경된다.")
+    @Test
+    void whenDeleteFolderExecutedDeleteAllBookmarks() {
+        // given
+
+        // when
+
+        // then
+    }
+}

--- a/src/test/java/com/hyun/bookmarkshare/manage/folder/dao/FolderRepositoryDeleteQueryTest.java
+++ b/src/test/java/com/hyun/bookmarkshare/manage/folder/dao/FolderRepositoryDeleteQueryTest.java
@@ -34,6 +34,6 @@ public class FolderRepositoryDeleteQueryTest {
 
         // then
         assertThat(deletedRows).isEqualTo(1);
-        assertThat(folderRepository.findByFolderSeqEvenIfDeleted(2L).get().getFolderDelFlag()).isEqualTo("y");
+        assertThat(folderRepository.findByFolderSeq(2L).get().getFolderDelFlag()).isEqualTo("y");
     }
 }

--- a/src/test/java/com/hyun/bookmarkshare/manage/folder/dao/FolderRepositoryInsertQueryTest.java
+++ b/src/test/java/com/hyun/bookmarkshare/manage/folder/dao/FolderRepositoryInsertQueryTest.java
@@ -2,12 +2,15 @@ package com.hyun.bookmarkshare.manage.folder.dao;
 
 import com.hyun.bookmarkshare.manage.folder.entity.Folder;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.jdbc.core.JdbcTemplate;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
@@ -17,6 +20,13 @@ class FolderRepositoryInsertQueryTest {
 
     @Autowired
     private FolderRepository folderRepository;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void initEach(){
+        jdbcTemplate.update("ALTER TABLE TFOLDER AUTO_INCREMENT = 2");
+    }
 
     @DisplayName("새로운 폴더를 저장한다.")
     @Test
@@ -43,6 +53,58 @@ class FolderRepositoryInsertQueryTest {
         assertThat(folderRepository.findByFolderSeq(savedFolderSeq).get())
                 .extracting("folderSeq", "folderName")
                 .containsExactlyInAnyOrder(3L, "unitTest0222_1252");
-
     }
+
+    @DisplayName("새로운 폴더를 저장할 때, caption 을 입력하지 않으면 빈 문자열로 저장된다.")
+    @Test
+    void saveWhenCaptionIsNull() {
+        // given
+        Folder folder = Folder.builder()
+                .folderSeq(null)
+                .userId(1L)
+                .folderParentSeq(1L)
+                .folderRootFlag("n")
+                .folderName("folderName")
+                .folderCaption(null)
+                .folderOrder(null)
+                .folderScope("p")
+                .folderRegDate(null)
+                .folderModDate(null)
+                .folderDelFlag("n")
+                .build();
+        // when
+        folderRepository.save(folder);
+        // then
+        assertThat(folderRepository.findByFolderSeq(folder.getFolderSeq()).get())
+                .extracting("folderSeq", "userId", "folderCaption", "folderOrder")
+                .containsExactlyInAnyOrder(3L, 1L, "", 2L);
+    }
+
+    @DisplayName("새로운 폴더를 저장할 때, folderOrder 가 null 인 경우 동일 folderParentSeq 의 가장 큰 folderOrder 에 1 을 더한 값으로 저장된다.")
+    @Test
+    void saveWhenFolderOrderIsNull() {
+        // given
+        Folder folder = Folder.builder()
+                .folderSeq(3L)
+                .userId(1L)
+                .folderParentSeq(2L)
+                .folderRootFlag("n")
+                .folderName("folderName")
+                .folderCaption(null)
+                .folderOrder(null)
+                .folderScope("p")
+                .folderRegDate(null)
+                .folderModDate(null)
+                .folderDelFlag("n")
+                .build();
+
+        // when
+        folderRepository.save(folder);
+
+        // then
+        assertThat(folderRepository.findByFolderSeq(folder.getFolderSeq()).get())
+                .extracting("folderSeq", "userId", "folderOrder")
+                .containsExactlyInAnyOrder(3L, 1L, 1L);
+    }
+
 }

--- a/src/test/java/com/hyun/bookmarkshare/manage/folder/service/FolderServiceTest.java
+++ b/src/test/java/com/hyun/bookmarkshare/manage/folder/service/FolderServiceTest.java
@@ -1,0 +1,186 @@
+package com.hyun.bookmarkshare.manage.folder.service;
+
+import com.hyun.bookmarkshare.manage.folder.dao.FolderRepository;
+import com.hyun.bookmarkshare.manage.folder.entity.Folder;
+import com.hyun.bookmarkshare.manage.folder.service.request.FolderCreateServiceRequestDto;
+import com.hyun.bookmarkshare.manage.folder.service.request.FolderListServiceRequestDto;
+import com.hyun.bookmarkshare.manage.folder.service.request.FolderReorderServiceRequestDto;
+import com.hyun.bookmarkshare.manage.folder.service.request.FolderServiceRequestDto;
+import com.hyun.bookmarkshare.manage.folder.service.response.FolderReorderResponse;
+import com.hyun.bookmarkshare.manage.folder.service.response.FolderResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@SpringBootTest
+@Transactional
+public class FolderServiceTest {
+
+    @Autowired
+    FolderService folderService;
+    @Autowired
+    FolderRepository folderRepository;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void initEach(){
+        jdbcTemplate.update("ALTER TABLE TFOLDER AUTO_INCREMENT = 2");
+    }
+    
+    @DisplayName("폴더를 생성한다. 폴더 식별 번호는 가장 최근 폴더의 식별 번호에서 1 증가한 값이다.")
+    @Test
+    void createNewFolder() {
+        // given
+        FolderCreateServiceRequestDto requestDto = FolderCreateServiceRequestDto.builder()
+                .folderSeq(null)
+                .userId(1L)
+                .folderParentSeq(1L)
+                .folderName("folderName")
+                .folderCaption(null)
+                .folderScope("p")
+                .build();
+
+        // when
+        FolderResponse folderResponse = folderService.createFolder(requestDto);
+
+        // then
+        assertThat(folderResponse)
+                .extracting("folderSeq", "userId", "folderCaption", "folderOrder")
+                .containsExactlyInAnyOrder(3L, 1L, "", 2L);
+    }
+    
+    @DisplayName("특정 사용자의 특정 폴더에 존재하는 모든 폴더 리스트를 조회한다.")
+    @Test
+    void findFolderList() {
+        // given
+        FolderListServiceRequestDto requestDto = FolderListServiceRequestDto.builder()
+                .userId(1L)
+                .folderParentSeq(1L)
+                .build();
+        // when // then
+        assertThat(folderRepository.findAllByUserIdAndParentSeq(requestDto.getUserId(), requestDto.getFolderParentSeq()))
+                .hasSize(1)
+                .extracting("folderSeq", "userId", "folderParentSeq")
+                .containsExactlyInAnyOrder(
+                        tuple(2L, 1L, 1L)
+                );
+    }
+
+    @DisplayName("폴더 삭제 시, 해당 폴더의 deleteFlag 는 'y'로 변경되며, 해당 폴더의 하위폴더들도 모두 deleteFlag 가 'y'로 변경된다.")
+    @Test
+    void deleteFolder() {
+        // given
+        Folder folder3 = createFolder(1L, 2L, "folder3");
+        Folder folder4 = createFolder(1L, 2L, "folder4");
+        Folder folder5 = createFolder(1L, 2L, "folder5");
+        folderRepository.save(folder3);
+        folderRepository.save(folder4);
+        folderRepository.save(folder5);
+
+        FolderServiceRequestDto requestDto = FolderServiceRequestDto.builder()
+                .folderSeq(2L)
+                .userId(1L)
+                .folderParentSeq(1L)
+                .build();
+
+        // when
+        folderService.deleteFolder(requestDto);
+
+        // then
+        assertThat(folderRepository.findByFolderSeq(requestDto.getFolderSeq()).get().getFolderDelFlag()).isEqualTo("y");
+        assertThat(folderRepository.findByFolderSeq(folder3.getFolderSeq()).get().getFolderDelFlag()).isEqualTo("y");
+        assertThat(folderRepository.findByFolderSeq(folder4.getFolderSeq()).get().getFolderDelFlag()).isEqualTo("y");
+        assertThat(folderRepository.findByFolderSeq(folder5.getFolderSeq()).get().getFolderDelFlag()).isEqualTo("y");
+    }
+
+    @DisplayName("폴더 수정 시, 해당 폴더의 정보가 수정된다. 수정 가능한 속성은 폴더 이름, 폴더 설명, 폴더 공개 범위이다.")
+    @Test
+    void updateFolder() {
+        // given
+        Folder folder3 = createFolder(1L, 2L, "folder3", "folder3Caption", "p");
+        folderRepository.save(folder3);
+        FolderServiceRequestDto requestDto = FolderServiceRequestDto.builder()
+                .folderSeq(folder3.getFolderSeq())
+                .userId(folder3.getUserId())
+                .folderParentSeq(folder3.getFolderParentSeq())
+                .folderName("folder3Update")
+                .folderCaption("folder3CaptionUpdate")
+                .folderScope("o")
+                .build();
+        // when
+        folderService.updateFolder(requestDto);
+        // then
+        assertThat(folderRepository.findByFolderSeq(requestDto.getFolderSeq()).get())
+                .extracting("folderSeq", "folderName", "folderCaption", "folderScope")
+                .containsExactlyInAnyOrder(requestDto.getFolderSeq(), "folder3Update", "folder3CaptionUpdate", "o");
+    }
+
+    @DisplayName("폴더 정렬 순서를 변경한다.")
+    @Test
+    void updateFolderOrder() {
+        // given
+        Folder folder3 = createFolder(1L, 2L, "folder3");
+        Folder folder4 = createFolder(1L, 2L, "folder4");
+        Folder folder5 = createFolder(1L, 2L, "folder5");
+        Folder folder6 = createFolder(1L, 1L, "folder6");
+        folderRepository.save(folder3);
+        folderRepository.save(folder4);
+        folderRepository.save(folder5);
+        folderRepository.save(folder6);
+        FolderReorderServiceRequestDto requestDto1 = FolderReorderServiceRequestDto.builder()
+                .userId(1L)
+                .folderParentSeq(2L)
+                .folderSeqOrder(List.of(5L, 3L, 4L))
+                .build();
+        FolderReorderServiceRequestDto requestDto2 = FolderReorderServiceRequestDto.builder()
+                .userId(1L)
+                .folderParentSeq(1L)
+                .folderSeqOrder(List.of(6L, 2L))
+                .build();
+        // when
+        List<FolderReorderResponse> resultList = folderService.updateFolderOrder(List.of(requestDto1, requestDto2));
+        // then
+        assertThat(resultList).extracting("folderParentSeq", "folderSeqOrder")
+                .containsExactlyInAnyOrder(
+                        tuple(2L, List.of(5L, 3L, 4L)),
+                        tuple(1L, List.of(6L, 2L))
+                );
+    }
+
+    private Folder createFolder(Long userId, Long parentSeq, String folderName, String folderCaption, String folderScope){
+        return Folder.builder()
+                .folderSeq(null)
+                .userId(userId)
+                .folderParentSeq(parentSeq)
+                .folderOrder(null)
+                .folderRootFlag("n")
+                .folderName(folderName)
+                .folderCaption(folderCaption)
+                .folderScope(folderScope)
+                .folderRegDate(null)
+                .folderModDate(null)
+                .folderDelFlag("n")
+                .build();
+    }
+
+    private Folder createFolder(Long userId, Long parentSeq, String folderName) {
+        return createFolder(userId, parentSeq, folderName, "folderCaption", "p");
+    }
+
+
+
+}

--- a/src/test/java/com/hyun/bookmarkshare/user/dao/UserRepositorySelectQueryTest.java
+++ b/src/test/java/com/hyun/bookmarkshare/user/dao/UserRepositorySelectQueryTest.java
@@ -103,7 +103,7 @@ public class UserRepositorySelectQueryTest {
         userRepository.save(user);
         userRepository.deleteByUserId(user.getUserId());
         // when
-        Optional<User> resultUser = userRepository.findByUserIdAndState(user.getUserId(), "e");
+        Optional<User> resultUser = userRepository.findByUserIdAndUserState(user.getUserId(), "e");
         // then
         assertThat(resultUser.get()).extracting("userId", "userEmail", "userState")
                 .containsExactly(3L, "test3@test.com", "e");


### PR DESCRIPTION
Resolves #50 
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- folder service layer 의 integration test 생성

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- `FolderServiceImpl` 의 모든 메서드에 대한 테스트 메서드 생성.
- 특정 폴더 삭제 시, 폴더 내부에 포함된 모든 하위 폴더들도 삭제처리 하기 위해 재귀쿼리를 사용해 해결하였습니다.

## Request for Reviews
<!-- 어떤 부분을 중점으로 리뷰해 주었으면 하나요? -->
- Client 는 폴더 정렬 순서 수정 요청에 대한 응답을 받은 직후, 화면 재 랜더링을 위해 서버에 GET 요청을 전송합니다.
이러한 경우 `FolderServiceImpl` class 의 `updateFolderOrder` 메서드에서 수정된 모든 Folder 식별번호로 response data를 생성해 반환하는 형태 대신 void 를 반환해도 무방하지 않을까요? response data 를 생성하기 위한 자원 및 시간을 줄이고 응답 메시지의 크기도 줄이는 효과가 있습니다. 


### Reference

<!-- 참고 자료 -->
- 재귀 쿼리
   - https://stackoverflow.com/questions/20215744/how-to-create-a-mysql-hierarchical-recursive-query
   - https://inpa.tistory.com/entry/MYSQL-%F0%9F%93%9A-RECURSIVE-%EC%9E%AC%EA%B7%80-%EC%BF%BC%EB%A6%AC
   - https://allmana.tistory.com/134

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->
