### PR TITLE
chore(cicd): Update github actions workflow add root host and databas…

### DIFF
--- a/.github/workflows/github-actions-server.yaml
+++ b/.github/workflows/github-actions-server.yaml
@@ -1,5 +1,5 @@
-name: SpringBoot CICD with Gradle version 1.4.5 24-01-08
-# Delete mysql user
+name: SpringBoot CICD with Gradle version 1.4.6 24-01-08
+# Add root host, run database script
 
 on:
   push:
@@ -20,9 +20,13 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: ${{ secrets.MARIADB_ROOT_PASSWORD }}
           MYSQL_DATABASE: 'bookmarkshare-test'
+          MYSQL_ROOT_HOST: "%"
         ports:
           - 3306:3306
         options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
+        steps:
+          - uses: actions/checkout@v1
+          - run: mariadb -h 127.0.0.1 --port 3306 -u root -p${{ secrets.MARIADB_ROOT_PASSWORD }} -e 'CREATE DATABASE IF NOT EXISTS `bookmarkshare-test`;'
 
     steps:
       - name: Checkout the repo


### PR DESCRIPTION
…e script

Resolves #{이슈-번호}
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- 데이터베이스 연동 실패

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- test properties localhost 대신 127.0.0.1 으로 변경
- workflow `MYSQL_ROOT_HOST: "%"` 추가
- workflow `mariadb -h 127.0.0.1 --port 3306 -u root -p${{ secrets.MARIADB_ROOT_PASSWORD }} -e 'CREATE DATABASE IF NOT EXISTS `bookmarkshare-test`;'` 명령어 추가